### PR TITLE
5 day

### DIFF
--- a/core-spring/src/main/java/hello/core/AppConfig.java
+++ b/core-spring/src/main/java/hello/core/AppConfig.java
@@ -16,16 +16,19 @@ public class AppConfig {
 
     @Bean
     public MemberService memberService() {
+        System.out.println("call AppConfig.memberService");
         return new MemberServiceImpl(memberRepository());
     }
 
     @Bean
     public MemberRepository memberRepository() {
+        System.out.println("call AppConfig.memberRepository");
         return new MemoryMemberRepository();
     }
 
     @Bean
     public OrderService orderService() {
+        System.out.println("call AppConfig.orderService");
         return new OrderServiceImpl(memberRepository(), discountPolicy());
     }
 

--- a/core-spring/src/main/java/hello/core/AppConfig.java
+++ b/core-spring/src/main/java/hello/core/AppConfig.java
@@ -11,7 +11,7 @@ import hello.core.order.OrderServiceImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration
+@Configuration // 이걸 안해주면 싹다 호출해버림 CGLIB를 안씀 싱글톤 보장 x
 public class AppConfig {
 
     @Bean

--- a/core-spring/src/main/java/hello/core/member/MemberServiceImpl.java
+++ b/core-spring/src/main/java/hello/core/member/MemberServiceImpl.java
@@ -18,4 +18,9 @@ public class MemberServiceImpl implements MemberService {
     public Member findMember(Long memberId) {
         return memberRepository.findById(memberId);
     }
+
+    // 테스트 용도
+    public MemberRepository getMemberRepository() {
+        return memberRepository;
+    }
 }

--- a/core-spring/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/core-spring/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -27,4 +27,9 @@ public class OrderServiceImpl implements OrderService {
 
         return new Order(memberId, itemName, itemPrice, discountPrice); // 값 받아서 Order 생성
     }
+
+    //테스트 용도
+    public MemberRepository getMemberRepository() {
+        return memberRepository;
+    }
 }

--- a/core-spring/src/test/java/hello/core/singleton/ConfigurationSingletonTest.java
+++ b/core-spring/src/test/java/hello/core/singleton/ConfigurationSingletonTest.java
@@ -31,4 +31,11 @@ public class ConfigurationSingletonTest {
         Assertions.assertThat(orderService.getMemberRepository()).isSameAs(memberRepository);
     }
 
+    @Test
+    void configurationDeep(){
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+        AppConfig bean = ac.getBean(AppConfig.class);
+
+        System.out.println("bean = " + bean.getClass());
+    }
 }

--- a/core-spring/src/test/java/hello/core/singleton/ConfigurationSingletonTest.java
+++ b/core-spring/src/test/java/hello/core/singleton/ConfigurationSingletonTest.java
@@ -1,0 +1,34 @@
+package hello.core.singleton;
+
+import hello.core.AppConfig;
+import hello.core.member.MemberRepository;
+import hello.core.member.MemberServiceImpl;
+import hello.core.order.OrderServiceImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class ConfigurationSingletonTest {
+
+    @Test
+    void configurationTest() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+        MemberServiceImpl memberService = ac.getBean("memberService", MemberServiceImpl.class);
+        OrderServiceImpl orderService = ac.getBean("orderService", OrderServiceImpl.class);
+        MemberRepository memberRepository = ac.getBean("memberRepository", MemberRepository.class);
+
+        MemberRepository memberRepository1 = memberService.getMemberRepository();
+        MemberRepository memberRepository2 = orderService.getMemberRepository();
+
+
+        System.out.println("memberService -> memberRepository = " + memberRepository1);
+        System.out.println("orderService -> memberRepository = " + memberRepository2);
+        System.out.println("memberRepository = " + memberRepository);
+
+        Assertions.assertThat(memberService.getMemberRepository()).isSameAs(memberRepository);
+        Assertions.assertThat(orderService.getMemberRepository()).isSameAs(memberRepository);
+    }
+
+}

--- a/core-spring/src/test/java/hello/core/singleton/SingletonService.java
+++ b/core-spring/src/test/java/hello/core/singleton/SingletonService.java
@@ -1,0 +1,18 @@
+package hello.core.singleton;
+
+import java.sql.SQLClientInfoException;
+
+public class SingletonService {
+
+    private static final SingletonService instance = new SingletonService();
+
+    public static SingletonService getInstance() {
+        return instance;
+    }
+
+    private SingletonService() {}
+
+    public void logic() {
+        System.out.println("싱클톤 객체 로직 호출");
+    }
+}

--- a/core-spring/src/test/java/hello/core/singleton/SingletonTest.java
+++ b/core-spring/src/test/java/hello/core/singleton/SingletonTest.java
@@ -1,0 +1,40 @@
+package hello.core.singleton;
+
+import hello.core.AppConfig;
+import hello.core.member.MemberService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SingletonTest {
+
+    @Test
+    @DisplayName("스프링 없는 순수한 DI 컨테이너")
+    void pureContainer() {
+        AppConfig appConfig = new AppConfig();
+        //1. 조회 : 호출할 때 마다 객체를 생성
+        MemberService memberService1 = appConfig.memberService();
+
+        //2. 조회 : 호출할 때 마다 객체를 생성
+        MemberService memberService2 = appConfig.memberService();
+
+        //참조 값이 다른 것을 확인
+        System.out.println(memberService1);
+        System.out.println(memberService2);
+
+        // memberService1 != memberService2
+        Assertions.assertThat(memberService1).isNotSameAs(memberService2);
+    }
+
+    @Test
+    @DisplayName("싱글톤 패턴을 적용한 객체 사용")
+    void singletonServiceTest () {
+        SingletonService singletonService1 = SingletonService.getInstance();
+        SingletonService singletonService2 = SingletonService.getInstance();
+
+        System.out.println("singletonService1 = " + singletonService1);
+        System.out.println("singletonService2 = " + singletonService2);
+
+        Assertions.assertThat(singletonService1).isSameAs(singletonService2);
+    }
+}

--- a/core-spring/src/test/java/hello/core/singleton/SingletonTest.java
+++ b/core-spring/src/test/java/hello/core/singleton/SingletonTest.java
@@ -5,6 +5,8 @@ import hello.core.member.MemberService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public class SingletonTest {
 
@@ -28,7 +30,7 @@ public class SingletonTest {
 
     @Test
     @DisplayName("싱글톤 패턴을 적용한 객체 사용")
-    void singletonServiceTest () {
+    void singletonServiceTest() {
         SingletonService singletonService1 = SingletonService.getInstance();
         SingletonService singletonService2 = SingletonService.getInstance();
 
@@ -37,4 +39,20 @@ public class SingletonTest {
 
         Assertions.assertThat(singletonService1).isSameAs(singletonService2);
     }
+
+    @Test
+    @DisplayName("스프링 컨테이너와 싱글톤")
+    void springContainer() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+        MemberService memberService1 = ac.getBean("memberService", MemberService.class);
+        MemberService memberService2 = ac.getBean("memberService", MemberService.class);
+
+        //참조 값이 다른 것을 확인
+        System.out.println(memberService1);
+        System.out.println(memberService2);
+
+        // memberService1 != memberService2
+        Assertions.assertThat(memberService1).isSameAs(memberService2);
+    }
+
 }

--- a/core-spring/src/test/java/hello/core/singleton/StatefulService.java
+++ b/core-spring/src/test/java/hello/core/singleton/StatefulService.java
@@ -1,0 +1,16 @@
+package hello.core.singleton;
+
+public class StatefulService {
+
+//    private int price;
+
+    public int order(String name, int price) {
+        System.out.println("name = " + name +  " price = " + price);
+//        this.price = price; // 여기가 문제!
+        return price;
+    }
+
+//    public int getPrice() {
+//        return price;
+//    }
+}

--- a/core-spring/src/test/java/hello/core/singleton/StatefulServiceTest.java
+++ b/core-spring/src/test/java/hello/core/singleton/StatefulServiceTest.java
@@ -1,0 +1,41 @@
+package hello.core.singleton;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StatefulServiceTest {
+
+    @Test
+    void statefulServiceSingleTon() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+        StatefulService statefulService1 = ac.getBean(StatefulService.class);
+        StatefulService statefulService2 = ac.getBean(StatefulService.class);
+
+        // ThreadA :  A사용자 10000원 주문
+//        statefulService1.order("user A", 10000);
+        int userAPrice = statefulService1.order("user A", 10000);
+        // ThreadA :  B사용자 20000원 주문
+//        statefulService2.order("user A", 20000);
+        int userBPrice = statefulService2.order("user A", 20000);
+
+        // ThreadA : 사용자 A 주문 금액 조회
+//        int price = statefulService1.getPrice();
+        System.out.println("price = " + userAPrice);
+
+//        Assertions.assertThat(statefulService1.getPrice()).isEqualTo(20000);
+
+    }
+
+    static class TestConfig{
+        @Bean
+        public StatefulService statefulService(){
+            return new StatefulService();
+        }
+    }
+
+}


### PR DESCRIPTION
### 싱글톤 패턴
- 스프링 없이 순수한 DI 컨테이너인 AppConfig는 요청을 할 때마다 객체를 새로 생성
- 트래픽이 초당 100이 나오면 초당 100개 객체가 생성되고 소멸 -> 메모리 낭비
- 해당 객체가 1개만 생성되고, 공유하도록 설계 -> 싱글톤 패턴
- 클래스의 인스턴스가 딱 1개만 생성되는 것을 보장하는 디자인 패턴
- 객체 인스턴스를 2개 이상 생성하지 못하도록 막아야 함

### 싱글톤 패턴 문제점
- 구현 코드가 복잡함
- 의존관계상 클라이언트가 구체 클래스에 의존 (DIP 위반)
- 클라이언트가 구체 클래스에 의존해 OCP를 위반할 가능성 높음

### 싱글톤 컨테이너
- 스프링 컨테이너는 싱글턴 패턴을 적용하지 않아도, 객체 인스턴스를 싱글톤으로 관리
- 스프링 컨테이너는 싱글톤 컨테이너 역할을 함
- 싱글톤 객체를 생성하고 관리하는 기능을 싱글톤 레지스트리라 함
- 싱글톤 패턴을 위한 지저분한 코드가 들어가지 않아도 됨
- DIP, OCP, 테스트, private 생성자로부터 자유롭게 싱글톤 사용

### 싱글톤 방식의 주의점
- 여러 클라이언트가 하나의 같은 객체 인스턴스를 공유하기 때문에 싱글톤 객체는 상태를 유지(stateful)하게 설계 X
- 특정 클라이언트에 의존적인 필드가 있으면 안됨
- 특정 클라이언트가 값을 변경할 수 있는 필드가 있으면 안됨
- 가급적 읽기만 가능
- 필드 대신에 공유되지 않는, 지역변수, 파라미터, ThreadLocal등을 사용
- (코드에서는 A가 10000원이고 B가 20000원이면 직후의 price가 20000이 되는 문제)

### @Configuration과 싱글톤 & 바이트코드 조작
- 스프링이 CGLIB라는 바이트코드 조작 라이브러리를 사용해서 AppConfig 클래스를 상속받은 임의의 다른 클래스를 만들어 스프링 빈으로 등록
- 싱글톤이 보장되도록 해줌

### @Bean만 적용한다면?
- MemberRepository가 호출될 때마다 다른 인스턴스로 생성
- @Bean만 사용해도 스프링 빈으로 등록되지만, 싱글톤 보장 X
- 그냥 쓰면 됨
