### PR TITLE
6 day

### DIFF
--- a/core-spring/src/main/java/hello/core/AutoAppConfig.java
+++ b/core-spring/src/main/java/hello/core/AutoAppConfig.java
@@ -1,0 +1,13 @@
+package hello.core;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+@Configuration
+@ComponentScan(
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Configuration.class)
+)
+public class AutoAppConfig {
+
+}

--- a/core-spring/src/main/java/hello/core/AutoAppConfig.java
+++ b/core-spring/src/main/java/hello/core/AutoAppConfig.java
@@ -1,5 +1,8 @@
 package hello.core;
 
+import hello.core.member.MemberRepository;
+import hello.core.member.MemoryMemberRepository;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
@@ -10,4 +13,8 @@ import org.springframework.context.annotation.FilterType;
 )
 public class AutoAppConfig {
 
+//    @Bean(name = "memoryMemberRepository")
+//    MemberRepository memberRepository() {
+//        return new MemoryMemberRepository();
+//    }
 }

--- a/core-spring/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/core-spring/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -2,7 +2,9 @@ package hello.core.discount;
 
 import hello.core.member.Grade;
 import hello.core.member.Member;
+import org.springframework.stereotype.Component;
 
+@Component
 public class RateDiscountPolicy implements DiscountPolicy {
 
     private int discountPercent = 10;

--- a/core-spring/src/main/java/hello/core/member/MemberServiceImpl.java
+++ b/core-spring/src/main/java/hello/core/member/MemberServiceImpl.java
@@ -1,10 +1,15 @@
 package hello.core.member;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
 public class MemberServiceImpl implements MemberService {
 
 //    private final MemberRepository memberRepository = new MemoryMemberRepository();
     private MemberRepository memberRepository;
 
+    @Autowired  //ac.getBean(MemberRepository.class)
     public MemberServiceImpl(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }

--- a/core-spring/src/main/java/hello/core/member/MemoryMemberRepository.java
+++ b/core-spring/src/main/java/hello/core/member/MemoryMemberRepository.java
@@ -1,8 +1,10 @@
 package hello.core.member;
 
+import org.springframework.stereotype.Component;
+
 import java.util.HashMap;
 import java.util.Map;
-
+@Component
 public class MemoryMemberRepository implements MemberRepository{
 
     private static Map<Long, Member> store = new HashMap<>();

--- a/core-spring/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/core-spring/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -6,7 +6,10 @@ import hello.core.discount.RateDiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberRepository;
 import hello.core.member.MemoryMemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class OrderServiceImpl implements OrderService {
 
 //    private final MemberRepository memberRepository = new MemoryMemberRepository();
@@ -15,6 +18,7 @@ public class OrderServiceImpl implements OrderService {
     private MemberRepository memberRepository;
     private DiscountPolicy discountPolicy;
 
+    @Autowired
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) { // fix or rate 들어오는 걸로
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;

--- a/core-spring/src/test/java/hello/core/scan/AutoAppConfigTest.java
+++ b/core-spring/src/test/java/hello/core/scan/AutoAppConfigTest.java
@@ -1,0 +1,18 @@
+package hello.core.scan;
+
+import hello.core.AutoAppConfig;
+import hello.core.member.MemberService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class AutoAppConfigTest {
+
+    @Test
+    void basicScan(){
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class);
+
+        MemberService memberService = ac.getBean(MemberService.class);
+        Assertions.assertThat(memberService).isInstanceOf(MemberService.class);
+    }
+}

--- a/core-spring/src/test/java/hello/core/scan/filter/BeanA.java
+++ b/core-spring/src/test/java/hello/core/scan/filter/BeanA.java
@@ -1,0 +1,5 @@
+package hello.core.scan.filter;
+
+@MyIncludeComponent
+public class BeanA {
+}

--- a/core-spring/src/test/java/hello/core/scan/filter/BeanB.java
+++ b/core-spring/src/test/java/hello/core/scan/filter/BeanB.java
@@ -1,0 +1,5 @@
+package hello.core.scan.filter;
+
+@MyExcludeComponent
+public class BeanB {
+}

--- a/core-spring/src/test/java/hello/core/scan/filter/ComponentFilterAppConfigTest.java
+++ b/core-spring/src/test/java/hello/core/scan/filter/ComponentFilterAppConfigTest.java
@@ -1,0 +1,36 @@
+package hello.core.scan.filter;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+public class ComponentFilterAppConfigTest {
+
+    @Test
+    void filterScan() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(ComponentFilterAppConfig.class);
+        BeanA beanA = ac.getBean("beanA", BeanA.class);
+        Assertions.assertThat(beanA).isNotNull();
+
+        org.junit.jupiter.api.Assertions.assertThrows(
+                NoSuchBeanDefinitionException.class,
+                () -> ac.getBean("beanB", BeanB.class)
+
+        );
+    }
+
+    @Configuration
+    @ComponentScan(
+            includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = MyIncludeComponent.class),
+            excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = MyExcludeComponent.class)
+    )
+    static class ComponentFilterAppConfig {
+
+    }
+
+}

--- a/core-spring/src/test/java/hello/core/scan/filter/MyExcludeComponent.java
+++ b/core-spring/src/test/java/hello/core/scan/filter/MyExcludeComponent.java
@@ -1,0 +1,9 @@
+package hello.core.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyExcludeComponent {
+}

--- a/core-spring/src/test/java/hello/core/scan/filter/MyIncludeComponent.java
+++ b/core-spring/src/test/java/hello/core/scan/filter/MyIncludeComponent.java
@@ -1,0 +1,9 @@
+package hello.core.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyIncludeComponent {
+}


### PR DESCRIPTION
### ComponentScan
- @ Component 애노테이션이 붙은 클래스를 스캔해서 스프링 빈으로 등록
- 기존의 AppConfig에서는 @ Bean으로 직접 설정 정보 작성, 의존 관계 명시를 했으나, 이제는 @ Autowired로 자동 주입

### @ ComponentScan
- @ ComponentScan은 @ Component가 붙은 모든 클래스를 스프링 빈으로 등록
- 스프링 빈의 기본 이름은 클래스명을 사용하나 맨 앞글자만 소문자
- 직접 지정하고 싶으면 @ Comoponent("memberService2")

### @ Autowired
- 생성자에 @Autowired를 지정하면, 스프링 컨테이너가 자동으로 해당 스프링 빈을 찾아 주입
- 기본 조회 전략은 타입이 같은 빈을 찾아서 주입
- getBean(MemberRepository.class)와 동일
- 생성자에 파라미터가 많아도 자동으로 주입

### 컴포넌트 스캔 기본 대상
- @ Component : 컴포넌트 스캔에서 사용
- @ Controller : 스프링 MVC 컨트롤러에 사용
- @ Service : 스프링 비즈니스 로직에서 사용
- @ Repository : 스프링 데이터 접근 계층에서 사용
- @ Configuration : 스프링 설정 정보에서 사용

### 중복 등록과 충돌
- 자동 빈 등록 vs 자동 빈 등록 -> ConflictingBeanDefinitionException
- 수동 빈 등록 vs 자동 빈 등록 -> 수동 빈이 자동 빈을 오버라이딩 -> 스프링 부트 에러 발생